### PR TITLE
Handle non-string ChatKit endpoints

### DIFF
--- a/dist/nodes/OpenAIChatKit/ChatKitAgentBuilder.node.js
+++ b/dist/nodes/OpenAIChatKit/ChatKitAgentBuilder.node.js
@@ -107,9 +107,38 @@ async function chatKitRequest(itemIndex, method, endpoint, body, timeout) {
             itemIndex,
         });
     }
-    const baseUrl = (credentials.baseUrl || 'https://api.openai.com').replace(/\/+$/u, '');
-    const path = endpoint.replace(/^\/+/, '');
-    const url = `${baseUrl}/${path}`;
+    const baseUrlString = credentials.baseUrl?.trim() || 'https://api.openai.com';
+    let url;
+    try {
+        let endpointValue;
+        if (endpoint instanceof URL) {
+            endpointValue = endpoint.toString();
+        }
+        else if (Array.isArray(endpoint)) {
+            endpointValue = endpoint.join('/');
+        }
+        else {
+            endpointValue = endpoint;
+        }
+        if (typeof endpointValue !== 'string') {
+            throw new Error('Endpoint must be a string or URL.');
+        }
+        const trimmedEndpoint = endpointValue.trim();
+        if (!trimmedEndpoint) {
+            throw new Error('Endpoint path is empty');
+        }
+        let endpointPath = trimmedEndpoint;
+        if (!/^https?:\/\//i.test(endpointPath)) {
+            endpointPath = endpointPath.startsWith('/') ? endpointPath : `/${endpointPath}`;
+        }
+        url = new URL(endpointPath, baseUrlString).toString();
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : 'Invalid base URL';
+        throw new n8n_workflow_1.NodeOperationError(this.getNode(), `Failed to resolve ChatKit URL: ${message}`, {
+            itemIndex,
+        });
+    }
     try {
         const response = await axios_1.default.request({
             method,


### PR DESCRIPTION
## Summary
- normalize ChatKit endpoint arguments by accepting URL and array inputs before resolving the request URL so TypeScript validations succeed during publish
- rebuild the compiled distribution bundle to capture the updated request handling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e46f1fee408321bc576cf40c36eed5