### PR TITLE
Simplify ChatKit endpoint normalization

### DIFF
--- a/dist/nodes/OpenAIChatKit/ChatKitAgentBuilder.node.js
+++ b/dist/nodes/OpenAIChatKit/ChatKitAgentBuilder.node.js
@@ -107,9 +107,71 @@ async function chatKitRequest(itemIndex, method, endpoint, body, timeout) {
             itemIndex,
         });
     }
-    const baseUrl = (credentials.baseUrl || 'https://api.openai.com').replace(/\/+$/u, '');
-    const path = endpoint.replace(/^\/+/, '');
-    const url = `${baseUrl}/${path}`;
+    const baseUrlString = credentials.baseUrl?.trim() || 'https://api.openai.com';
+    let baseUrl;
+    try {
+        baseUrl = new URL(baseUrlString);
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : 'Invalid base URL';
+        throw new n8n_workflow_1.NodeOperationError(this.getNode(), `Failed to resolve ChatKit URL: ${message}`, {
+            itemIndex,
+        });
+    }
+    if (!baseUrl.pathname.endsWith('/')) {
+        baseUrl.pathname = `${baseUrl.pathname.replace(/\/+$/, '')}/`;
+    }
+    const basePathSegments = baseUrl.pathname.split('/').filter((segment) => segment.length > 0);
+    const basePathSegmentsLower = basePathSegments.map((segment) => segment.toLowerCase());
+    let url;
+    try {
+        if (endpoint instanceof URL) {
+            url = endpoint.toString();
+        }
+        else {
+            const endpointValue = Array.isArray(endpoint) ? endpoint.join('/') : endpoint;
+            const trimmedEndpoint = endpointValue.trim();
+            if (!trimmedEndpoint) {
+                throw new Error('Endpoint path is empty');
+            }
+            if (/^https?:\/\//i.test(trimmedEndpoint)) {
+                url = trimmedEndpoint;
+            }
+            else {
+                const normalizedEndpoint = trimmedEndpoint.startsWith('/')
+                    ? trimmedEndpoint
+                    : `/${trimmedEndpoint}`;
+                const endpointUrl = new URL(normalizedEndpoint, 'http://placeholder');
+                const endpointSegments = endpointUrl.pathname
+                    .split('/')
+                    .filter((segment) => segment.length > 0);
+                const dedupedSegments = [...endpointSegments];
+                let baseIndex = 0;
+                while (dedupedSegments.length > 0 &&
+                    baseIndex < basePathSegmentsLower.length &&
+                    dedupedSegments[0].toLowerCase() === basePathSegmentsLower[baseIndex]) {
+                    dedupedSegments.shift();
+                    baseIndex += 1;
+                }
+                const combinedSegments = [...basePathSegments, ...dedupedSegments];
+                let finalPath = combinedSegments.length ? `/${combinedSegments.join('/')}` : '/';
+                if (endpointUrl.pathname.endsWith('/') && !finalPath.endsWith('/')) {
+                    finalPath += '/';
+                }
+                const resolvedUrl = new URL(baseUrl.toString());
+                resolvedUrl.pathname = finalPath;
+                resolvedUrl.search = endpointUrl.search;
+                resolvedUrl.hash = endpointUrl.hash;
+                url = resolvedUrl.toString();
+            }
+        }
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : 'Invalid base URL';
+        throw new n8n_workflow_1.NodeOperationError(this.getNode(), `Failed to resolve ChatKit URL: ${message}`, {
+            itemIndex,
+        });
+    }
     try {
         const response = await axios_1.default.request({
             method,

--- a/nodes/OpenAIChatKit/ChatKitAgentBuilder.node.ts
+++ b/nodes/OpenAIChatKit/ChatKitAgentBuilder.node.ts
@@ -122,7 +122,7 @@ async function chatKitRequest(
   this: IExecuteFunctions,
   itemIndex: number,
   method: 'GET' | 'POST' | 'DELETE',
-  endpoint: string,
+  endpoint: string | URL | string[],
   body?: IDataObject,
   timeout?: number,
 ): Promise<IDataObject> {
@@ -134,9 +134,81 @@ async function chatKitRequest(
     });
   }
 
-  const baseUrl = (credentials.baseUrl || 'https://api.openai.com').replace(/\/+$/u, '');
-  const path = endpoint.replace(/^\/+/, '');
-  const url = `${baseUrl}/${path}`;
+  const baseUrlString = credentials.baseUrl?.trim() || 'https://api.openai.com';
+  let baseUrl: URL;
+
+  try {
+    baseUrl = new URL(baseUrlString);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid base URL';
+    throw new NodeOperationError(this.getNode(), `Failed to resolve ChatKit URL: ${message}`, {
+      itemIndex,
+    });
+  }
+
+  if (!baseUrl.pathname.endsWith('/')) {
+    baseUrl.pathname = `${baseUrl.pathname.replace(/\/+$/, '')}/`;
+  }
+
+  const basePathSegments = baseUrl.pathname.split('/').filter((segment) => segment.length > 0);
+  const basePathSegmentsLower = basePathSegments.map((segment) => segment.toLowerCase());
+
+  let url: string;
+
+  try {
+    if (endpoint instanceof URL) {
+      url = endpoint.toString();
+    } else {
+      const endpointValue = Array.isArray(endpoint) ? endpoint.join('/') : endpoint;
+      const trimmedEndpoint = endpointValue.trim();
+
+      if (!trimmedEndpoint) {
+        throw new Error('Endpoint path is empty');
+      }
+
+      if (/^https?:\/\//i.test(trimmedEndpoint)) {
+        url = trimmedEndpoint;
+      } else {
+        const normalizedEndpoint = trimmedEndpoint.startsWith('/')
+          ? trimmedEndpoint
+          : `/${trimmedEndpoint}`;
+        const endpointUrl = new URL(normalizedEndpoint, 'http://placeholder');
+        const endpointSegments = endpointUrl.pathname
+          .split('/')
+          .filter((segment) => segment.length > 0);
+        const dedupedSegments = [...endpointSegments];
+        let baseIndex = 0;
+
+        while (
+          dedupedSegments.length > 0 &&
+          baseIndex < basePathSegmentsLower.length &&
+          dedupedSegments[0].toLowerCase() === basePathSegmentsLower[baseIndex]
+        ) {
+          dedupedSegments.shift();
+          baseIndex += 1;
+        }
+
+        const combinedSegments = [...basePathSegments, ...dedupedSegments];
+        let finalPath = combinedSegments.length ? `/${combinedSegments.join('/')}` : '/';
+
+        if (endpointUrl.pathname.endsWith('/') && !finalPath.endsWith('/')) {
+          finalPath += '/';
+        }
+
+        const resolvedUrl = new URL(baseUrl.toString());
+        resolvedUrl.pathname = finalPath;
+        resolvedUrl.search = endpointUrl.search;
+        resolvedUrl.hash = endpointUrl.hash;
+
+        url = resolvedUrl.toString();
+      }
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid base URL';
+    throw new NodeOperationError(this.getNode(), `Failed to resolve ChatKit URL: ${message}`, {
+      itemIndex,
+    });
+  }
 
   try {
     const response = await axios.request<IDataObject>({


### PR DESCRIPTION
## Summary
- normalize ChatKit base URLs while preserving trailing slashes for predictable resolution
- deduplicate overlapping base path segments when composing request endpoints without TypeScript union errors
- rebuild the compiled distribution bundle with the updated URL handling logic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e46f1fee408321bc576cf40c36eed5