### PR TITLE
Normalize ChatKit endpoint resolution

### DIFF
--- a/nodes/OpenAIChatKit/ChatKitAgentBuilder.node.ts
+++ b/nodes/OpenAIChatKit/ChatKitAgentBuilder.node.ts
@@ -122,7 +122,7 @@ async function chatKitRequest(
   this: IExecuteFunctions,
   itemIndex: number,
   method: 'GET' | 'POST' | 'DELETE',
-  endpoint: string,
+  endpoint: string | URL | string[],
   body?: IDataObject,
   timeout?: number,
 ): Promise<IDataObject> {
@@ -134,9 +134,95 @@ async function chatKitRequest(
     });
   }
 
-  const baseUrl = (credentials.baseUrl || 'https://api.openai.com').replace(/\/+$/u, '');
-  const path = endpoint.replace(/^\/+/, '');
-  const url = `${baseUrl}/${path}`;
+  const baseUrlString = credentials.baseUrl?.trim() || 'https://api.openai.com';
+
+  let baseUrl: URL;
+
+  try {
+    baseUrl = new URL(baseUrlString);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid base URL';
+    throw new NodeOperationError(this.getNode(), `Failed to resolve ChatKit URL: ${message}`, {
+      itemIndex,
+    });
+  }
+
+  const normalisePathSegments = (path: string): string[] =>
+    path
+      .split('/')
+      .map((segment) => segment.trim())
+      .filter((segment) => segment.length > 0);
+
+  const resolveEndpointUrl = (input: string | URL | string[]): URL => {
+    if (input instanceof URL) {
+      return input;
+    }
+
+    const endpointJoined = Array.isArray(input) ? input.join('/') : input;
+    const endpointRaw = endpointJoined.trim();
+
+    if (!endpointRaw) {
+      throw new Error('Endpoint path is empty');
+    }
+
+    if (/^https?:\/\//i.test(endpointRaw)) {
+      return new URL(endpointRaw);
+    }
+
+    const endpointUrl = new URL(
+      endpointRaw.startsWith('/') ? endpointRaw : `/${endpointRaw}`,
+      'http://placeholder',
+    );
+
+    const baseSegments = normalisePathSegments(baseUrl.pathname);
+    const endpointSegments = normalisePathSegments(endpointUrl.pathname);
+    const baseSegmentsLower = baseSegments.map((segment) => segment.toLowerCase());
+    const endpointSegmentsLower = endpointSegments.map((segment) => segment.toLowerCase());
+
+    let overlap = 0;
+    const maxOverlap = Math.min(baseSegmentsLower.length, endpointSegmentsLower.length);
+
+    for (let length = maxOverlap; length > 0; length -= 1) {
+      const baseSuffix = baseSegmentsLower.slice(-length).join('/');
+      const endpointPrefix = endpointSegmentsLower.slice(0, length).join('/');
+
+      if (baseSuffix === endpointPrefix) {
+        overlap = length;
+        break;
+      }
+    }
+
+    const mergedSegments = baseSegments.concat(endpointSegments.slice(overlap));
+    const result = new URL(baseUrl.toString());
+    result.pathname = mergedSegments.length > 0 ? `/${mergedSegments.join('/')}` : '/';
+
+    const hasTrailingSlash = endpointUrl.pathname.endsWith('/');
+
+    if (hasTrailingSlash && !result.pathname.endsWith('/')) {
+      result.pathname = `${result.pathname}/`;
+    }
+
+    if (endpointUrl.search) {
+      result.search = endpointUrl.search;
+    }
+
+    if (endpointUrl.hash) {
+      result.hash = endpointUrl.hash;
+    }
+
+    return result;
+  };
+
+  let url: string;
+
+  try {
+    url = resolveEndpointUrl(endpoint).toString();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid endpoint';
+    throw new NodeOperationError(this.getNode(), `Failed to resolve ChatKit URL: ${message}`, {
+      itemIndex,
+    });
+  }
 
   try {
     const response = await axios.request<IDataObject>({


### PR DESCRIPTION
## Summary
- normalise ChatKit base and endpoint path segments through a typed helper to avoid duplicate declarations and TypeScript publish errors
- ensure trailing slashes, queries, and hashes are preserved while composing final request URLs
- rebuild the compiled ChatKit node so the distribution reflects the new resolution logic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e46f1fee408321bc576cf40c36eed5